### PR TITLE
fix undefined index: clear_cache

### DIFF
--- a/SlimCachingManager/ResourceHandler/Textfile.php
+++ b/SlimCachingManager/ResourceHandler/Textfile.php
@@ -140,7 +140,7 @@ class Textfile implements IResourceHandler
         $obj->setETag($res['etag']);
         $obj->setResource($res['resource']);
         $obj->setLifeTime($res['lifetime']);
-        $obj->setExpiryDate($res['clear_cache']);
+        $obj->setExpiryDate($res['expiry_date']);
         $obj->setLastModified($res['last_modified']);
         return $obj;
     }


### PR DESCRIPTION
Fixes the following Slim Error page: 

```
Details
Type: ErrorException
Code: 8
Message: Undefined index: clear_cache
File: /home/httpd/xxxx/vendor/maegnes/slim-caching-manager/SlimCachingManager/ResourceHandler/Textfile.php
Line: 143
```
